### PR TITLE
redirection when delete suggestion on suggestions index

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -28,10 +28,6 @@ class ItemsController < ApplicationController
 private
 
   def item_params
-    if params[:suggestion_name]
-      return { name: params[:suggestion_name] }
-    else
       params.require(:item).permit(:name, :shared)
-    end
   end
 end

--- a/app/controllers/suggestions_controller.rb
+++ b/app/controllers/suggestions_controller.rb
@@ -16,13 +16,17 @@ class SuggestionsController < ApplicationController
     end
   end
 
+  def destroy
+    @item = Item.find(params[:id])
+    authorize @item
+    @item.destroy
+    redirect_back(fallback_location: root_path)
+  end
+
   private
 
   def item_params
-    if params[:suggestion_name]
-      return { name: params[:suggestion_name] }
-    else
-      params.require(:item).permit(:name, :shared)
-    end
+    params[:suggestion_name] = { name: params[:suggestion_name] }
+    params.require(:suggestion_name).permit(:name)
   end
 end

--- a/app/views/suggestions/index.html.erb
+++ b/app/views/suggestions/index.html.erb
@@ -11,7 +11,7 @@
           <div class="card-body d-flex justify-content-between align-items-center p-3 rounded-4">
             <% if @suitcase.items.include?(Item.find_by(name: suggestion.name)) %>
               <div class="item-text-minus"><%= suggestion.name %></div>
-              <%= link_to item_path(Item.find_by(name: suggestion.name)), method: :delete do %>
+              <%= link_to suggestion_path(Item.find_by(name: suggestion.name)), method: :delete do %>
                 <i class="far fa-minus-square"></i>
               <% end %>
             <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,4 +15,5 @@ Rails.application.routes.draw do
   resources :items, only: [:destroy] do
     resource :tick, only: [:update]
   end
+  resources :suggestions, only: [:destroy]
 end


### PR DESCRIPTION
- Route for suggestion destroy created, this route will be used from now instead of items#destroy.
- Destroy method created in suggestions controller.
- Clean of the item controller (no need of suggestion params modifications when item is a suggestion, because we have a suggestions controller).
